### PR TITLE
Fix: Correct variable scope for log paths in task_prefix.sh

### DIFF
--- a/utli_bash/task_prefix.sh
+++ b/utli_bash/task_prefix.sh
@@ -15,13 +15,12 @@ function date_get_ymdhms() {
   minute1=$(date -jf "%Y-%m-%d" "$date_str" +"%M")
   second1=$(date -jf "%Y-%m-%d" "$date_str" +"%S")
 
-  # Optional: print the results
-  echo "Year: $year1, Month: $month1, Day: $day1, Hour: $hour1, Minute: $minute1, Second: $second1"
+  echo "$year1 $month1 $day1 $hour1 $minute1 $second1"
 }
 
 
-
-date_get_ymdhms
+# Call the function and read the values into local variables
+read year1 month1 day1 hour1 minute1 second1 <<< "$(date_get_ymdhms)"
 
 dirlog="ztmp/log/year=$year1/month=$month1/day=$day1"
 mkdir -p  $dirlog


### PR DESCRIPTION
The date_get_ymdhms function in utli_bash/task_prefix.sh set date component variables (year1, month1, etc.) which were then used to define log paths. Due to scoping issues, these variables were not always available when constructing the log directory and filename, leading to incorrect log paths (e.g., ztmp/log/year=/month=/day=/task___.log).

This fix modifies the date_get_ymdhms function to echo the date components as a space-separated string. The calling part of the script now captures these values into local variables, ensuring they are correctly populated before being used to define dirlog and logfile237. This guarantees the log paths are generated with the correct date and time components.